### PR TITLE
Option to skip scanning of files that exceed specified size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ clamd-url       = http://host:port/
 log-file        = /var/log/clammit.log
 debug           = true
 test-pages      = true
+max-file-size   = 25MB
 ```
 
 Setting                  | Description
@@ -144,6 +145,7 @@ content-memory-threshold | (Optional) Maximum payload size to keep in RAM. Large
 log-file                 | (Optional) The clammit log file, if ommitted will log to stdout
 test-pages               | (Optional) If true, clammit will also offer up a page to perform test uploads
 debug                    | (Optional) If true, more things will be logged
+max-file-size            | (Optional) The maximum file size to scan. Files larger than this will not be scanned. Default 25MB
 
 The listen address can be a TCP port or Unix socket, e.g.:
 
@@ -155,6 +157,8 @@ The same format applies to the `clamd-url` and `application-url` parameters.
 By default Clammit will look for a `X-Clammit-Backend` header, and use that to
 decide where to send requests to. If you only have one backend server, you can
 set it in the `application-url` configuration option, and omit the header.
+
+The `max-file-size` setting allows you to specify a maximum file size for scanning. If an uploaded file size exceeds this limit, the file will not be scanned. This can be specified as a string using units like "KB", "MB", or "GB". For example, "10MB" would set the maximum file size to 10 megabytes. If this setting is not provided, the default value is 25MB.
 
 ## Architecture
 

--- a/clammit.cfg.example
+++ b/clammit.cfg.example
@@ -27,6 +27,13 @@ clamd-url       = unix:/var/run/clamav/clamd.ctl
 log-file        = log/clammit.log
 
 #
+# The maximum file size to scan. Files larger than this will not be scanned.
+# This can be specified as a string using units like "KB", "MB", or "GB".
+# For example, "10MB" would set the maximum file size to 10 megabytes.
+# If this setting is not provided, the default value is 25MB.
+#max-file-size = 10MB
+
+#
 # Set this to true to have this application serve an upload form to test
 # the virus scanning
 #

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ type ApplicationConfig struct {
 	// Number of CPU threads to use
 	NumThreads int `gcfg:"num-threads"`
 	// Maximum file size to scan
-	MaxFileSize int64 `gcfg:"max-file-size"`
+	MaxFileSize string `gcfg:"max-file-size"`
 }
 
 // Default configuration

--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ var DefaultApplicationConfig = ApplicationConfig{
 	TestPages:              true,
 	Debug:                  false,
 	NumThreads:             runtime.NumCPU(),
+	MaxFileSize:            "25MB",
 }
 
 // Application context

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"gopkg.in/gcfg.v1"
 	"log"
 	"net"
 	"net/http"
@@ -23,6 +22,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"gopkg.in/gcfg.v1"
 )
 
 /* This is for Go Releaser.
@@ -30,9 +31,7 @@ import (
  */
 var version = "master"
 
-//
 // Configuration structure, designed for gcfg
-//
 type Config struct {
 	App ApplicationConfig `gcfg:"application"`
 }
@@ -78,11 +77,11 @@ type ApplicationConfig struct {
 	Debug bool `gcfg:"debug"`
 	// Number of CPU threads to use
 	NumThreads int `gcfg:"num-threads"`
+	// Maximum file size to scan
+	MaxFileSize int64 `gcfg:"max-file-size"`
 }
 
-//
 // Default configuration
-//
 var DefaultApplicationConfig = ApplicationConfig{
 	Listen:                 ":8438",
 	SocketPerms:            "0777",
@@ -96,9 +95,7 @@ var DefaultApplicationConfig = ApplicationConfig{
 	NumThreads:             runtime.NumCPU(),
 }
 
-//
 // Application context
-//
 type Ctx struct {
 	Config          Config
 	ApplicationURL  *url.URL
@@ -110,9 +107,7 @@ type Ctx struct {
 	ShuttingDown    bool
 }
 
-//
 // JSON server information response
-//
 type Info struct {
 	Version             string `json:"clammit_version"`
 	Address             string `json:"scan_server_url"`
@@ -122,9 +117,7 @@ type Info struct {
 	TestScanCleanResult string `json:"test_scan_clean"`
 }
 
-//
 // Global variables and config
-//
 var ctx *Ctx
 var configFile string
 var EICAR = []byte(`X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*`)

--- a/scan_interceptor.go
+++ b/scan_interceptor.go
@@ -15,9 +15,7 @@ import (
 	"net/http"
 )
 
-//
 // The implementation of the Scan interceptor
-//
 type ScanInterceptor struct {
 	VirusStatusCode int
 	Scanner         scanner.Scanner
@@ -31,6 +29,12 @@ type ScanInterceptor struct {
  * returns True if the body contains a virus
  */
 func (c *ScanInterceptor) Handle(w http.ResponseWriter, req *http.Request, body io.Reader) bool {
+	// If the content length is greater than 1MB, forward the request without scanning.
+	if req.ContentLength > 1024*1024 {
+		ctx.Logger.Println("Not scanning file larger than 1MB")
+		return false
+	}
+
 	//
 	// Don't care unless we have some content. When the length is unknown, the length will be -1,
 	// but we attempt anyway to read the body.

--- a/scan_interceptor.go
+++ b/scan_interceptor.go
@@ -29,9 +29,9 @@ type ScanInterceptor struct {
  * returns True if the body contains a virus
  */
 func (c *ScanInterceptor) Handle(w http.ResponseWriter, req *http.Request, body io.Reader) bool {
-	// If the content length is greater than 1MB, forward the request without scanning.
-	if req.ContentLength > 1024*1024 {
-		ctx.Logger.Println("Not scanning file larger than 1MB")
+	// Don't scan if the content length is too large
+	if req.ContentLength > ctx.Config.App.MaxFileSize {
+		ctx.Logger.Printf("Not scanning file larger than %d bytes", ctx.Config.App.MaxFileSize)
 		return false
 	}
 

--- a/scan_interceptor.go
+++ b/scan_interceptor.go
@@ -55,15 +55,19 @@ func (b *ByteSize) Set(s string) error {
 func (c *ScanInterceptor) Handle(w http.ResponseWriter, req *http.Request, body io.Reader) bool {
 	// Convert MaxFileSize from string to int64
 	var maxSize ByteSize
-	err := maxSize.Set(ctx.Config.App.MaxFileSize)
-	if err != nil {
-		ctx.Logger.Printf("Error parsing max file size: %v", err)
-		return false
-	}
-	// Don't scan if the content length is too large
-	if req.ContentLength > int64(maxSize) {
-		ctx.Logger.Printf("Not scanning file larger than %s", ctx.Config.App.MaxFileSize)
-		return false
+	if ctx.Config.App.MaxFileSize != "" {
+		err := maxSize.Set(ctx.Config.App.MaxFileSize)
+		if err != nil {
+			ctx.Logger.Printf("Error parsing max file size: %v", err)
+			http.Error(w, "Bad Request", 400)
+			// Return true to indicate an error condition
+			return true
+		}
+		// Don't scan if the content length is too large
+		if req.ContentLength > int64(maxSize) {
+			ctx.Logger.Printf("Not scanning file larger than %s", ctx.Config.App.MaxFileSize)
+			return false
+		}
 	}
 
 	//


### PR DESCRIPTION
This PR introduces a new configuration variable, `MaxFileSize`, to Clammit. This variable allows users to specify a maximum file size for scanning. If an uploaded file size exceeds this limit, the file will not be scanned and be uploaded directly to the backend.

Here are the specific changes made:

1. In `main.go`, a new `MaxFileSize` field has been added to the `ApplicationConfig` struct. This field is a string that allows the maximum file size to be read from the configuration file.

2. In `interceptor.go`, the `Handle` method has been updated. Now, it converts `MaxFileSize` from a string to an `int64` before comparing it with `req.ContentLength`. If the size of the request exceeds `MaxFileSize`, the method logs a message and returns `false`, skipping the scan.

3. Error handling has been added to the `Handle` method in `interceptor.go` to manage any errors that occur while parsing the `MaxFileSize` string. If an error occurs, the function logs a message with the error and returns a http bad request.

This new feature provides users with more control over the scanning process, allowing them to skip scanning for larger files and optimize performance.
 
