### PR TITLE
fix: set custom response time metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Clammit can send metrics to a StatsD server. To enable this, configure the `stat
 
 Metrics collected include:
 
-* `scan.response_time` - Histogram of the time taken to process each scan request
+* `scan.response_time` - Gauge of the time taken to process each scan request
 * `scan.failed` - Count of the number of failed scan requests
 * `scan.processed` - Count of the number of processed scan requests
 * `scan.viruses_found` - Count of the number of viruses found

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"log"
-	"sort"
 	"sync"
 	"time"
 
@@ -69,26 +68,7 @@ func sendMetricsToDatadog(duration time.Duration, fileCount int, virusesFound in
 		log.Println("StatsD client not initialized, skipping metrics sending")
 		return
 	}
-
-	durations = append(durations, duration)
-	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
-	count := len(durations)
-	sum := 0.0
-	for _, d := range durations {
-		sum += float64(d / time.Millisecond)
-	}
-	avg := sum / float64(count)
-	median := float64(durations[count/2] / time.Millisecond)
-	max := float64(durations[count-1] / time.Millisecond)
-	p95 := float64(durations[int(float64(count)*0.95)] / time.Millisecond)
-
-	// Send custom metrics
-	statsdClient.Gauge("scan.response_time_avg", avg, nil, 1)
-	statsdClient.Gauge("scan.response_time_median", median, nil, 1)
-	statsdClient.Gauge("scan.response_time_max", max, nil, 1)
-	statsdClient.Gauge("scan.response_time_p95", p95, nil, 1)
-
-	// Send other metrics
+	statsdClient.Gauge("scan.response_time", float64(duration/time.Millisecond), nil, 1)
 	statsdClient.Count("scan.failed", int64(metrics.FilesFailedToProcess), nil, 1)
 	statsdClient.Count("scan.processed", int64(fileCount), nil, 1)
 	statsdClient.Count("scan.viruses_found", int64(virusesFound), nil, 1)


### PR DESCRIPTION
This PR to efficiently display the response time of scanned files.
Here's an example:

![image](https://github.com/user-attachments/assets/dab1044b-f668-4e4b-a27e-6f6c677f14fb)

- the graph represents the response time for scanned files with a legend for `avg` `mix` `max` `sum` `current value`


